### PR TITLE
fixed in case no options given for generate_key

### DIFF
--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -195,6 +195,7 @@ speakeasy.ascii_to_hex = function(str) {
 //
 speakeasy.generate_key = function(options) {
   // options
+  if(!options) options = {};
   var length = options.length || 32;
   var name = options.name || "Secret Key";
   var qr_codes = options.qr_codes || false;


### PR DESCRIPTION
Since generate_keys has defaults, users are inclined to think they can just call the function without a paramater but it breaks if options is null.