### PR TITLE
Use crypto.randomBytes as CSPRNG

### DIFF
--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -207,7 +207,7 @@ speakeasy.generate_key = function(options) {
   }
 
   // generate an ascii key
-  var key = this.generate_key_ascii(length, symbols);
+  var key = this.generate_key_ascii(length);
   
   // return a SecretKey with ascii, hex, and base32
   var SecretKey = {};
@@ -233,28 +233,14 @@ speakeasy.generate_key = function(options) {
   return SecretKey;
 }
 
-// speakeasy.generate_key_ascii(length, symbols)
+// speakeasy.generate_key_ascii(length)
 //
 // Generates a random key, of length `length` (default 32).
-// Also choose whether you want symbols, default false.
-// speakeasy.generate_key() wraps around this.
 //
-speakeasy.generate_key_ascii = function(length, symbols) {
-  if (!length) length = 32;
-
-  var set = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';
-
-  if (symbols) {
-    set += '!@#$%^&*()<>?/[]{},.:;';
-  }
-  
-  var key = '';
-
-  for(var i=0; i < length; i++) {
-    key += set.charAt(Math.floor(Math.random() * set.length));
-  }
-  
-  return key;
+speakeasy.generate_key_ascii = function(length) {
+    if(!length) length = 32;
+    var buf = crypto.randomBytes(length);
+    return buf.toString('ascii');
 }
 
 // alias, not the TV show

--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -177,16 +177,15 @@ speakeasy.ascii_to_hex = function(str) {
 
 // speakeasy.generate_key(options)
 //
-// Generates a random key with the set A-Z a-z 0-9 and symbols, of any length
-// (default 32). Returns the key in ASCII, hexadecimal, and base32 format.
-// Base32 format is used in Google Authenticator. Turn off symbols by setting
-// symbols: false. Automatically generate links to QR codes of each encoding
+// Generates a random key  of any length (default 32). 
+// Returns the key in ASCII, hexadecimal, and base32 format.
+// Base32 format is used in Google Authenticator. 
+// Automatically generate links to QR codes of each encoding
 // (using the Google Charts API) by setting qr_codes: true. Automatically
 // generate a link to a special QR code for use with the Google Authenticator
 // app, for which you can also specify a name.
 //
 // options.length(=32)              length of key
-//        .symbols(=true)           include symbols in the key
 //        .qr_codes(=false)         generate links to QR codes
 //        .google_auth_qr(=false)   generate a link to a QR code to scan
 //                                  with the Google Authenticator app.
@@ -199,12 +198,6 @@ speakeasy.generate_key = function(options) {
   var name = options.name || "Secret Key";
   var qr_codes = options.qr_codes || false;
   var google_auth_qr = options.google_auth_qr || false;
-  var symbols = true;
-
-  // turn off symbols only when explicity told to
-  if (options.symbols !== undefined && options.symbols === false) {
-    symbols = false;
-  }
 
   // generate an ascii key
   var key = this.generate_key_ascii(length);


### PR DESCRIPTION
As described in http://tools.ietf.org/html/rfc6238#section-5.1, you should rely on a cryptographically-secure random number generator that is what `crypto.randomBytes()` is.

`Math.random()` is not safe.