### PR TITLE
Fix hotp zero-padding bug

### DIFF
--- a/lib/speakeasy.js
+++ b/lib/speakeasy.js
@@ -92,13 +92,8 @@ speakeasy.hotp = function(options) {
                 |(digest_bytes[offset+2] & 0xff) << 8
                 |(digest_bytes[offset+3] & 0xff);
 
-  bin_code = bin_code.toString();
+  var code = speakeasy.bin_to_string(bin_code, length);
 
-  // get the chars at position bin_code - length through length chars
-  var sub_start = bin_code.length - length;
-  var code = bin_code.substr(sub_start, length);
-  
-  // we now have a code with `length` number of digits, so return it
   return(code);
 }
 
@@ -139,6 +134,31 @@ speakeasy.totp = function(options) {
 
   // return the code
   return(code);
+}
+
+// speakeasy.bin_to_string(bin, length)
+//
+// helper function to convert a number to a string of given length.
+//
+speakeasy.bin_to_string = function(bin, length) {
+  var bin_str = bin.toString();
+
+  if (bin_str.length < length) {
+    // pad with 0's
+    var pad = '';
+    var padLength = length - bin_str.length;
+    for (var j = 0; j < padLength; ++j) {
+      pad += '0';
+    }
+
+    return pad + bin_str;
+  } else {
+    // get the chars at position bin_code - length through length chars
+    var sub_start = bin_str.length - length;
+    var code = bin_str.substr(sub_start, length);
+
+    return code;
+  }
 }
 
 // speakeasy.hex_to_ascii(key)

--- a/test/test_hotp.js
+++ b/test/test_hotp.js
@@ -56,4 +56,15 @@ vows.describe('HOTP Counter-Based Algorithm Test').addBatch({
       assert.equal(topic, '338314');
     }
   },
+
+  'Test 0-padding encoding with key = \'h/,Iv]ET34!].kfNUU^Nf!I#gp1bNT1C\' at counter 3 and length = 8': {
+    topic: function() {
+      return speakeasy.hotp({key: 'h/,Iv]ET34!].kfNUU^Nf!I#gp1bNT1C', length: 8, counter: 3});
+    },
+
+    'correct one-time password returned': function(topic) {
+      assert.equal(topic, '05314231');
+    }
+  },
+
 }).exportTo(module);


### PR DESCRIPTION
Numbers with fewer non-zero digits than the required length would be truncated.
This fix ensures proper zero padding.